### PR TITLE
clipp: Improve performance by passing parameters as const references

### DIFF
--- a/include/clipp.h
+++ b/include/clipp.h
@@ -3835,7 +3835,7 @@ greedy(parameter p) {
 }
 
 inline parameter
-operator ! (parameter p) {
+operator ! (const parameter& p) {
     return greedy(p);
 }
 
@@ -6851,7 +6851,7 @@ private:
  *****************************************************************************/
 inline man_page
 make_man_page(const group& cli,
-              doc_string progname = "",
+              const doc_string& progname = "",
               const doc_formatting& fmt = doc_formatting{})
 {
     man_page man;


### PR DESCRIPTION
This patch addresses performance warnings reported by cppcheck by changing the way parameters are passed in two functions.

- In the `operator!` function, the `parameter` type is now passed by const reference instead of by value. This avoids unnecessary copying of the parameter, improving performance.
- In the `make_man_page` function, the `doc_string` type is now passed by const reference instead of by value. This change also avoids unnecessary copying and enhances performance.

These changes ensure that the functions are more efficient, especially when dealing with larger objects or complex types.